### PR TITLE
Automatic link refactoring

### DIFF
--- a/frontend/src/routes/Home.svelte
+++ b/frontend/src/routes/Home.svelte
@@ -26,6 +26,29 @@
     },
   });
 
+  /**
+   * EventHandler for onBeforeInput event. If a complete jitsi url is pasted into the input field,
+   * the domain and conference are extracted automatically.
+   *
+   * @param event - The onBeforeInput event
+   */
+  function beforeInput(event: Event) {
+    if (event instanceof InputEvent && event.data && event.inputType === "insertFromPaste") {
+      const { data } = event;
+      const urlRegex = new RegExp('^http(s?)://(.*)/(.*)$');
+      if (!urlRegex.test(data)) return;
+      const execArray = urlRegex.exec(data);
+      if (!(execArray && execArray.length >= 4)) return;
+      const domain = execArray[2];
+      const conference = execArray[3];
+      if (domainRegex.test(domain) && jitsiRoomRegex.test(conference)) {
+        event.preventDefault();
+        $form.domain = domain;
+        $form.room = conference;
+      }
+    }
+  }
+
   $: href = `${$form.domain || "meet.jit.si"}/${$form.room}`;
 </script>
 
@@ -54,6 +77,7 @@
           type="text"
           id="domain"
           name="domain"
+          on:beforeinput={beforeInput}
           on:change={handleChange}
           bind:value={$form.domain}
           placeholder="meet.jit.si"
@@ -73,6 +97,7 @@
           type="text"
           id="room"
           name="room"
+          on:beforeinput={beforeInput}
           on:change={handleChange}
           bind:value={$form.room}
           class="w-full bg-white rounded border border-gray-300 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out"


### PR DESCRIPTION
closes #10

## Description
<!--
  Describe your changes in detail.
-->
Added automatic link refactoring. When pasting jitsi url into an input field, the instance and conference are extracted automatically.

## Screenshots
<!--
  If you have any screenshots, please paste them here. Remove this section if it is not necessary.
-->
Pasting the url `https://jitsi.example.com/conference` into an input field

Previously:
![image](https://user-images.githubusercontent.com/30511472/143772662-f4f31de2-fab5-470e-a7aa-e8f7b070b6de.png)

Now:
![image](https://user-images.githubusercontent.com/30511472/143772723-232c009e-d45f-4d65-807a-d096281212ce.png)

## Checklist
<!--
  Go over all the following points, and put an `x` in all boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] Make sure you are requesting to `dev`. Don't request to `main` branch!
- [x] I have linked related issue.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
